### PR TITLE
chore(.htaccess): Update Apache access control syntax

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -22,6 +22,5 @@
 
 # Optional: Deny access to sensitive files
 <FilesMatch "^\.env|composer\.json|composer\.lock">
-    Order allow,deny
-    Deny from all
+    Require all denied
 </FilesMatch>


### PR DESCRIPTION
- Replace deprecated Order/Deny directives with modern Require syntax
- Improve compatibility with Apache 2.4+ configurations
- Maintain protection of sensitive files (.env, composer.json, composer.lock)
- Sir, good day po! Since I tried LavaLust in advance, I discovered a few issues. When I tried to access LavaLust on localhost via my WAMP Server v3.3.7 with Apache 2.4.62, I was getting a 500 Internal Server Error and couldn't load the project at all.

After investigating, I found that the cause was in `public/.htaccess`. It was using the old Apache 2.2 access control syntax:

```apache
Order allow,deny
Deny from all
```

This directive is no longer supported in Apache 2.4 since `mod_authz_host` was replaced. Apache 2.4 uses a different syntax, which caused the server to throw a 500 error immediately on any request.

The fix was replacing it with the modern Apache 2.4 equivalent:

```apache
Require all denied
```

I already submitted a pull request (#71) with the fix. This will affect any user running Apache 2.4+, which is the current standard, so it's worth merging. Hope this helps po!
