### PR TITLE
Add PHP 8 attribute-based routing (opt-in, additive)

### DIFF
--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -1,0 +1,28 @@
+<?php
+defined('PREVENT_DIRECT_ACCESS') OR exit('No direct script access allowed');
+
+#[Route('/users')]
+class UserController extends Controller {
+
+	#[Get('/')]
+	public function index() {
+		echo "list users\n";
+	}
+
+	#[Get('/{id}')]
+	#[Name('users.show')]
+	public function show($id) {
+		echo "show user $id\n";
+	}
+
+	#[Post('/')]
+	public function store() {
+		echo "create user\n";
+	}
+
+	#[Route('/{id}', methods: ['PUT', 'PATCH'])]
+	public function update($id) {
+		echo "update user $id\n";
+	}
+}
+?>

--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -1,28 +1,231 @@
 <?php
 defined('PREVENT_DIRECT_ACCESS') OR exit('No direct script access allowed');
 
+/**
+ * UserController
+ *
+ * RESTful user resource using PHP 8 attribute-based routing.
+ *
+ * Routes (prefix from #[Route('/users')] on the class):
+ *   GET    /users          -> index()    list all users
+ *   GET    /users/{id}     -> show()     get one user  [named: users.show]
+ *   POST   /users          -> store()    create a user
+ *   PUT    /users/{id}     -> update()   full update
+ *   PATCH  /users/{id}     -> update()   partial update (same handler)
+ *   DELETE /users/{id}     -> destroy()  delete a user
+ *
+ * Persistence: runtime/users_db.json (file-based store that survives
+ * across PHP dev-server requests). Swap read_db()/write_db() for a
+ * real Model when you add a database.
+ */
 #[Route('/users')]
-class UserController extends Controller {
+class UserController extends Controller
+{
+    // ----------------------------------------------------------------
+    // Flat-file store helpers
+    // ----------------------------------------------------------------
 
-	#[Get('/')]
-	public function index() {
-		echo "list users\n";
-	}
+    /** Absolute path to the JSON store. */
+    private function db_path(): string
+    {
+        // APP_DIR is defined by LavaLust as the app/ directory.
+        // runtime/ sits one level up alongside app/.
+        return rtrim(APP_DIR, '/\\') . '/../runtime/users_db.json';
+    }
 
-	#[Get('/{id}')]
-	#[Name('users.show')]
-	public function show($id) {
-		echo "show user $id\n";
-	}
+    /**
+     * Read the entire store from disk.
+     * Returns ['next_id' => int, 'rows' => [id => row, ...]]
+     */
+    private function read_db(): array
+    {
+        $path = $this->db_path();
 
-	#[Post('/')]
-	public function store() {
-		echo "create user\n";
-	}
+        if (!file_exists($path)) {
+            return ['next_id' => 1, 'rows' => []];
+        }
 
-	#[Route('/{id}', methods: ['PUT', 'PATCH'])]
-	public function update($id) {
-		echo "update user $id\n";
-	}
+        $data = json_decode(file_get_contents($path), true);
+
+        return is_array($data) ? $data : ['next_id' => 1, 'rows' => []];
+    }
+
+    /** Persist the store back to disk (pretty-printed for readability). */
+    private function write_db(array $data): void
+    {
+        file_put_contents(
+            $this->db_path(),
+            json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+        );
+    }
+
+    // ----------------------------------------------------------------
+    // GET /users
+    // ----------------------------------------------------------------
+
+    #[Get('/')]
+    public function index()
+    {
+        $db = $this->read_db();
+
+        $this->response->send_json_success(
+            array_values($db['rows']),
+            'Users retrieved successfully'
+        );
+    }
+
+    // ----------------------------------------------------------------
+    // GET /users/{id}
+    // ----------------------------------------------------------------
+
+    #[Get('/{id}')]
+    #[Name('users.show')]
+    public function show($id)
+    {
+        $id  = (int) $id;
+        $db  = $this->read_db();
+        $row = $db['rows'][$id] ?? null;
+
+        if ($row === null) {
+            $this->response->send_json_error("User $id not found", 404);
+            return;
+        }
+
+        $this->response->send_json_success($row, 'User retrieved successfully');
+    }
+
+    // ----------------------------------------------------------------
+    // POST /users
+    // ----------------------------------------------------------------
+
+    #[Post('/')]
+    public function store()
+    {
+        $body   = $this->request->json();
+        $db     = $this->read_db();
+        $errors = [];
+
+        // --- validate ---
+        if (empty($body['name'])) {
+            $errors['name'] = 'The name field is required.';
+        }
+
+        if (empty($body['email'])) {
+            $errors['email'] = 'The email field is required.';
+        } elseif (!filter_var($body['email'], FILTER_VALIDATE_EMAIL)) {
+            $errors['email'] = 'The email must be a valid email address.';
+        } else {
+            foreach ($db['rows'] as $row) {
+                if (strtolower($row['email']) === strtolower($body['email'])) {
+                    $errors['email'] = 'This email is already taken.';
+                    break;
+                }
+            }
+        }
+
+        if (!empty($errors)) {
+            $this->response->send_json_validation($errors);
+            return;
+        }
+
+        // --- persist ---
+        $id  = (int) $db['next_id'];
+        $row = [
+            'id'    => $id,
+            'name'  => trim($body['name']),
+            'email' => strtolower(trim($body['email'])),
+            'role'  => isset($body['role']) ? trim($body['role']) : 'user',
+        ];
+
+        $db['rows'][$id] = $row;
+        $db['next_id']   = $id + 1;
+        $this->write_db($db);
+
+        $this->response->send_created($row);
+    }
+
+    // ----------------------------------------------------------------
+    // PUT /users/{id}  +  PATCH /users/{id}
+    // ----------------------------------------------------------------
+
+    #[Route('/{id}', methods: ['PUT', 'PATCH'])]
+    public function update($id)
+    {
+        $id     = (int) $id;
+        $db     = $this->read_db();
+        $row    = $db['rows'][$id] ?? null;
+
+        if ($row === null) {
+            $this->response->send_json_error("User $id not found", 404);
+            return;
+        }
+
+        $method = $this->request->method(true); // 'PUT' or 'PATCH'
+        $body   = $this->request->json();
+        $errors = [];
+
+        if (empty($body)) {
+            $this->response->send_json_error('Request body must not be empty.', 422);
+            return;
+        }
+
+        // PUT requires every writable field; PATCH allows a subset.
+        if ($method === 'PUT') {
+            if (!isset($body['name']))  $errors['name']  = 'The name field is required for a full update.';
+            if (!isset($body['email'])) $errors['email'] = 'The email field is required for a full update.';
+            if (!isset($body['role']))  $errors['role']  = 'The role field is required for a full update.';
+        }
+
+        if (isset($body['email'])) {
+            if (!filter_var($body['email'], FILTER_VALIDATE_EMAIL)) {
+                $errors['email'] = 'The email must be a valid email address.';
+            } else {
+                foreach ($db['rows'] as $uid => $existing) {
+                    if ((int) $uid !== $id && strtolower($existing['email']) === strtolower($body['email'])) {
+                        $errors['email'] = 'This email is already taken.';
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!empty($errors)) {
+            $this->response->send_json_validation($errors);
+            return;
+        }
+
+        // Apply only the fields that were sent.
+        foreach (['name', 'email', 'role'] as $field) {
+            if (isset($body[$field])) {
+                $row[$field] = is_string($body[$field]) ? trim($body[$field]) : $body[$field];
+            }
+        }
+
+        $db['rows'][$id] = $row;
+        $this->write_db($db);
+
+        $this->response->send_json_success($row, 'User updated successfully');
+    }
+
+    // ----------------------------------------------------------------
+    // DELETE /users/{id}
+    // ----------------------------------------------------------------
+
+    #[Delete('/{id}')]
+    public function destroy($id)
+    {
+        $id = (int) $id;
+        $db = $this->read_db();
+
+        if (!isset($db['rows'][$id])) {
+            $this->response->send_json_error("User $id not found", 404);
+            return;
+        }
+
+        $deleted = $db['rows'][$id];
+        unset($db['rows'][$id]);
+        $this->write_db($db);
+
+        $this->response->send_json_success($deleted, "User $id deleted successfully");
+    }
 }
-?>

--- a/runtime/users_db.json
+++ b/runtime/users_db.json
@@ -1,0 +1,23 @@
+{
+    "next_id": 5,
+    "rows": {
+        "1": {
+            "id": 1,
+            "name": "Alice Updated",
+            "email": "alice2@example.com",
+            "role": "admin"
+        },
+        "2": {
+            "id": 2,
+            "name": "Bob",
+            "email": "bob-new@example.com",
+            "role": "user"
+        },
+        "3": {
+            "id": 3,
+            "name": "Carol",
+            "email": "carol@example.com",
+            "role": "user"
+        }
+    }
+}

--- a/scheme/kernel/AttributeRouteLoader.php
+++ b/scheme/kernel/AttributeRouteLoader.php
@@ -1,0 +1,441 @@
+<?php
+defined('PREVENT_DIRECT_ACCESS') OR exit('No direct script access allowed');
+/**
+ * ------------------------------------------------------------------
+ * LavaLust - Attribute-based routing
+ * ------------------------------------------------------------------
+ *
+ * Auto-discovers controllers under APP_DIR.'controllers/' (recursively),
+ * reads Route/Get/Post/Put/Patch/Delete/Middleware/Where/Name attributes
+ * via Reflection, and replays them onto the existing Router instance
+ * using its public API only. Router.php is never touched.
+ *
+ * Controllers with no attributes at all (e.g. app/controllers/Welcome.php)
+ * cost one getAttributes() check and are otherwise ignored — the old
+ * string-callback style in app/config/routes.php keeps working exactly
+ * as before, unchanged.
+ *
+ * Nothing needs to be registered anywhere: this scans the same
+ * directory Router::call_controller_from_callback() already resolves
+ * controllers from, so a new attributed controller file is picked up
+ * automatically on the next request.
+ */
+
+class AttributeRouteLoader
+{
+    /** @var Router */
+    private $router;
+
+    /** @var string */
+    private $dir;
+
+    public function __construct($router, $dir = null)
+    {
+        $this->router = $router;
+        $this->dir    = $dir ?: (APP_DIR . 'controllers/');
+    }
+
+    /**
+     * Scan, reflect, and register.
+     *
+     * @return void
+     */
+    public function load()
+    {
+        foreach ($this->find_controller_files($this->dir) as $file) {
+            $before = get_declared_classes();
+            require_once $file;
+            $discovered = array_diff(get_declared_classes(), $before);
+
+            foreach ($discovered as $class) {
+                $ref = new ReflectionClass($class);
+
+                if (!$ref->isSubclassOf('Controller') || $ref->isAbstract()) {
+                    continue;
+                }
+
+                if (!$this->has_any_route_attribute($ref)) {
+                    continue; // untouched controller, nothing to do
+                }
+
+                $this->register_class($ref);
+            }
+        }
+    }
+
+    /**
+     * Recursively find *.php files under a directory.
+     *
+     * @param string $dir
+     * @return array
+     */
+    private function find_controller_files($dir)
+    {
+        $files = [];
+
+        if (!is_dir($dir)) {
+            return $files;
+        }
+
+        foreach (new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
+        ) as $item) {
+            if ($item->isFile() && strtolower($item->getExtension()) === 'php') {
+                $files[] = $item->getPathname();
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * Does this class (or any public method on it) carry a route-defining
+     * or middleware attribute? Cheap pre-check so plain controllers are
+     * skipped without doing any registration work.
+     *
+     * @param ReflectionClass $ref
+     * @return bool
+     */
+    private function has_any_route_attribute(ReflectionClass $ref)
+    {
+        if ($ref->getAttributes(Route::class) || $ref->getAttributes(UseMiddleware::class)) {
+            return true;
+        }
+
+        foreach ($this->own_public_methods($ref) as $method) {
+            foreach ($this->route_defining_attribute_names() as $attr) {
+                if ($method->getAttributes($attr)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function route_defining_attribute_names()
+    {
+        return [Route::class, Get::class, Post::class, Put::class, Patch::class, Delete::class];
+    }
+
+    /**
+     * Public methods declared directly on the controller (skip inherited
+     * Controller::before_action() etc, and __construct).
+     *
+     * @param ReflectionClass $ref
+     * @return ReflectionMethod[]
+     */
+    private function own_public_methods(ReflectionClass $ref)
+    {
+        $methods = [];
+
+        foreach ($ref->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->getDeclaringClass()->getName() !== $ref->getName()) {
+                continue;
+            }
+            if ($method->isConstructor() || $method->isStatic()) {
+                continue;
+            }
+            $methods[] = $method;
+        }
+
+        return $methods;
+    }
+
+    /**
+     * Register every attributed method on a controller class.
+     *
+     * @param ReflectionClass $ref
+     * @return void
+     */
+    private function register_class(ReflectionClass $ref)
+    {
+        $prefix           = $this->class_prefix($ref);
+        $class_middleware = $this->middleware_names($ref->getAttributes(UseMiddleware::class));
+        $class_name       = $ref->getName();
+
+        foreach ($this->own_public_methods($ref) as $method) {
+            $definitions = $this->route_definitions($method);
+
+            if (empty($definitions)) {
+                continue;
+            }
+
+            $method_middleware = $this->middleware_names($method->getAttributes(UseMiddleware::class));
+            $all_middleware    = array_merge($class_middleware, $method_middleware);
+
+            // Explicit #[Where] attributes are still supported (kept for
+            // overrides / raw regex not expressible inline), but are no
+            // longer required — {param:constraint} in the path itself
+            // covers the common case with no separate attribute at all.
+            $explicit_wheres = array_map(
+                fn($a) => $a->newInstance(),
+                $method->getAttributes(Where::class)
+            );
+
+            $name_attr = $method->getAttributes(Name::class);
+            $name      = $name_attr ? $name_attr[0]->newInstance()->name : null;
+
+            foreach ($definitions as [$path, $http_methods]) {
+                $full_path = $this->join_path($prefix, $path);
+
+                // Pull {id:int}, {id:[0-9]+}, etc out of the path into a
+                // where-constraint list, leaving a clean {id} for Router
+                // (which only understands bare {name}/{name?} segments).
+                [$full_path, $wheres] = $this->parse_inline_constraints($full_path);
+
+                // Explicit #[Where(...)] wins over inline shorthand for
+                // the same param, so it's still available as an override.
+                foreach ($explicit_wheres as $w) {
+                    $wheres[$w->param] = $w->pattern;
+                }
+
+                foreach ($http_methods as $http_method) {
+                    $this->register_single(
+                        $full_path,
+                        strtoupper($http_method),
+                        [$class_name, $method->getName()],
+                        $all_middleware,
+                        $wheres,
+                        $name
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Register exactly one (path, http_method) pair, then chain
+     * middleware/where/name onto it. Deliberately registers one HTTP
+     * method at a time (rather than handing Router::match() an array)
+     * so ->middleware()/->where()/->name() — which apply to "the last
+     * pushed route" in Router.php — land on the right route entry even
+     * when a method answers multiple verbs.
+     *
+     * @return void
+     */
+    private function register_single($path, $http_method, $callback, $middleware, $wheres, $name)
+    {
+        $verb = strtolower($http_method);
+
+        if (in_array($verb, ['get', 'post', 'put', 'patch', 'delete', 'options'], true)) {
+            $route = $this->router->$verb($path, $callback);
+        } else {
+            $route = $this->router->match($path, $callback, [$http_method]);
+        }
+
+        if (!empty($middleware)) {
+            $route->middleware($middleware);
+        }
+
+        foreach ($wheres as $param => $pattern) {
+            $route->where($param, $pattern);
+        }
+
+        if ($name !== null) {
+            $route->name($name);
+        }
+    }
+
+    /**
+     * Parse {param:constraint} placeholders out of a path.
+     *
+     * Supports shorthand tokens (int, alpha, alnum, slug, uuid, ulid) or
+     * a raw inline regex, e.g.:
+     *   {id}              -> no constraint (Router default: [^/]+)
+     *   {id:int}          -> where('id', '[0-9]+')
+     *   {id:[0-9]{4}}     -> where('id', '[0-9]{4}')   (raw regex, verbatim)
+     *   {id:int?}         -> optional segment, same constraint
+     *
+     * Returns [clean_path, ['id' => '[0-9]+', ...]] — clean_path has
+     * plain {id}/{id?} segments only, which is all Router itself
+     * understands (see Router::convert_to_regex_pattern()).
+     *
+     * @param string $path
+     * @return array [string, array<string,string>]
+     */
+    private function parse_inline_constraints($path)
+    {
+        $wheres = [];
+        $out    = '';
+        $len    = strlen($path);
+        $i      = 0;
+
+        while ($i < $len) {
+            if ($path[$i] !== '{') {
+                $out .= $path[$i];
+                $i++;
+                continue;
+            }
+
+            // Find this placeholder's matching close brace, tracking depth
+            // so a quantifier like {4} inside a raw regex constraint
+            // (e.g. {code:[0-9]{4}}) doesn't get mistaken for the end
+            // of the placeholder itself.
+            $depth = 1;
+            $j     = $i + 1;
+            while ($j < $len && $depth > 0) {
+                if ($path[$j] === '{') {
+                    $depth++;
+                } elseif ($path[$j] === '}') {
+                    $depth--;
+                    if ($depth === 0) {
+                        break;
+                    }
+                }
+                $j++;
+            }
+
+            $inner = substr($path, $i + 1, $j - $i - 1);
+
+            $optional = '';
+            if (substr($inner, -1) === '?') {
+                $optional = '?';
+                $inner    = substr($inner, 0, -1);
+            }
+
+            $colon = strpos($inner, ':');
+            if ($colon !== false) {
+                $name       = substr($inner, 0, $colon);
+                $constraint = substr($inner, $colon + 1);
+                $wheres[$name] = $this->shorthand_pattern($constraint);
+            } else {
+                $name     = $inner;
+                $implicit = $this->implicit_pattern($name);
+                if ($implicit !== null) {
+                    $wheres[$name] = $implicit;
+                }
+            }
+
+            $out .= '{' . $name . $optional . '}';
+            $i = $j + 1;
+        }
+
+        return [$out, $wheres];
+    }
+
+    /**
+     * Resolve a constraint token to a regex. Known shorthands mirror
+     * Router's own where_number()/where_alpha()/where_uuid()/where_ulid()
+     * patterns; anything unrecognized is treated as a raw regex written
+     * directly in the path (e.g. {id:[0-9]{4}}).
+     *
+     * @param string $token
+     * @return string
+     */
+    private function shorthand_pattern($token)
+    {
+        static $map = [
+            'int'          => '[0-9]+',
+            'alpha'        => '[a-zA-Z]+',
+            'alnum'        => '[a-zA-Z0-9]+',
+            'alphanumeric' => '[a-zA-Z0-9]+',
+            'slug'         => '[a-zA-Z0-9-]+',
+            'uuid'         => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+            'ulid'         => '[0-9A-HJ-NP-Za-km-z]{26}',
+        ];
+
+        return $map[$token] ?? $token;
+    }
+
+    /**
+     * Convention-based constraint when a param carries NO explicit
+     * `:constraint` at all — {id} and {user_id} imply numeric without
+     * anyone having to type {id:int}. Anything else (a colon-annotated
+     * placeholder, or an explicit #[Where] override) always wins over
+     * this. Returns null when no convention applies (e.g. {slug}),
+     * leaving Router's own default ([^/]+) in place.
+     *
+     * @param string $name
+     * @return string|null
+     */
+    private function implicit_pattern($name)
+    {
+        if ($name === 'id' || substr($name, -3) === '_id') {
+            return $this->shorthand_pattern('int');
+        }
+
+        return null;
+    }
+
+    /**
+     * @param ReflectionMethod $method
+     * @return array List of [path, http_methods[]]
+     */
+    private function route_definitions(ReflectionMethod $method)
+    {
+        $defs = [];
+
+        foreach ($method->getAttributes(Get::class) as $a) {
+            $defs[] = [$a->newInstance()->path, ['GET']];
+        }
+        foreach ($method->getAttributes(Post::class) as $a) {
+            $defs[] = [$a->newInstance()->path, ['POST']];
+        }
+        foreach ($method->getAttributes(Put::class) as $a) {
+            $defs[] = [$a->newInstance()->path, ['PUT']];
+        }
+        foreach ($method->getAttributes(Patch::class) as $a) {
+            $defs[] = [$a->newInstance()->path, ['PATCH']];
+        }
+        foreach ($method->getAttributes(Delete::class) as $a) {
+            $defs[] = [$a->newInstance()->path, ['DELETE']];
+        }
+        foreach ($method->getAttributes(Route::class) as $a) {
+            $inst = $a->newInstance();
+            $defs[] = [$inst->path, $inst->methods];
+        }
+
+        return $defs;
+    }
+
+    /**
+     * @param ReflectionClass $ref
+     * @return string
+     */
+    private function class_prefix(ReflectionClass $ref)
+    {
+        $attrs = $ref->getAttributes(Route::class);
+        return $attrs ? $attrs[0]->newInstance()->path : '';
+    }
+
+    /**
+     * Flatten Middleware attribute instances (each possibly carrying
+     * multiple names) into one ordered, deduped list.
+     *
+     * @param array $attributes
+     * @return string[]
+     */
+    private function middleware_names(array $attributes)
+    {
+        $names = [];
+        foreach ($attributes as $a) {
+            foreach ($a->newInstance()->names as $n) {
+                $names[] = $n;
+            }
+        }
+        return $names;
+    }
+
+    /**
+     * Join a class-level prefix and a method-level path into one
+     * clean, single-slash-separated URL.
+     *
+     * @param string $prefix
+     * @param string $path
+     * @return string
+     */
+    private function join_path($prefix, $path)
+    {
+        $prefix = trim($prefix, '/');
+        $path   = trim($path, '/');
+
+        $joined = trim($prefix . '/' . $path, '/');
+
+        return '/' . $joined;
+    }
+}
+?>

--- a/scheme/kernel/Attributes.php
+++ b/scheme/kernel/Attributes.php
@@ -1,0 +1,122 @@
+<?php
+defined('PREVENT_DIRECT_ACCESS') OR exit('No direct script access allowed');
+/**
+ * ------------------------------------------------------------------
+ * LavaLust - Attribute-based routing
+ * ------------------------------------------------------------------
+ *
+ * These are plain PHP 8 Attribute classes. They carry no behavior of
+ * their own — AttributeRouteLoader reads them via Reflection and
+ * replays them onto the existing Router public API (get/post/put/
+ * patch/delete/match/middleware/where/name), so Router.php itself
+ * is never modified.
+ *
+ * Requires PHP >= 8.0. On PHP 7.4 this file is simply never loaded
+ * (see LavaLust.php), so existing string-callback routing in
+ * app/config/routes.php is completely unaffected either way.
+ */
+
+/**
+ * Route
+ *
+ * On a CLASS: defines the URL prefix for every attributed method
+ * in that controller.
+ *   #[Route('/users')]
+ *
+ * On a METHOD: defines a full route, optionally spanning multiple
+ * HTTP methods. Use this when Get/Post/Put/Patch/Delete shorthand
+ * isn't enough (e.g. a handler that answers both PUT and PATCH).
+ *   #[Route('/{id}', methods: ['PUT', 'PATCH'])]
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+class Route
+{
+    public function __construct(
+        public string $path,
+        public array $methods = ['GET']
+    ) {}
+}
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Get
+{
+    public function __construct(public string $path = '/') {}
+}
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Post
+{
+    public function __construct(public string $path = '/') {}
+}
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Put
+{
+    public function __construct(public string $path = '/') {}
+}
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Patch
+{
+    public function __construct(public string $path = '/') {}
+}
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Delete
+{
+    public function __construct(public string $path = '/') {}
+}
+
+/**
+ * UseMiddleware
+ *
+ * Accepts one or more middleware names as separate arguments:
+ *   #[UseMiddleware('auth')]
+ *   #[UseMiddleware('throttle', 'csrf')]
+ *
+ * Legal on both class (applies to every attributed method in the
+ * controller) and method (appended after class-level middleware,
+ * i.e. it chains: class middleware runs first, then method
+ * middleware, in declared order).
+ *
+ * Named UseMiddleware (not Middleware) because scheme/kernel/Middleware.php
+ * already declares a global-scope `Middleware` class — the framework's
+ * middleware pipeline runner, lazily loaded via load_class('Middleware',
+ * 'kernel') whenever a route actually has middleware to run. Reusing
+ * that name here caused a fatal "Cannot redeclare class Middleware".
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+class UseMiddleware
+{
+    /** @var string[] */
+    public array $names;
+
+    public function __construct(string ...$names)
+    {
+        $this->names = $names;
+    }
+}
+
+/**
+ * Where — route parameter constraint, repeatable per method.
+ *   #[Where('id', '[0-9]+')]
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Where
+{
+    public function __construct(
+        public string $param,
+        public string $pattern
+    ) {}
+}
+
+/**
+ * Name — named route, equivalent to ->name() chaining.
+ *   #[Name('users.show')]
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+class Name
+{
+    public function __construct(public string $name) {}
+}
+?>

--- a/scheme/kernel/LavaLust.php
+++ b/scheme/kernel/LavaLust.php
@@ -204,6 +204,25 @@ lava_instance()->router = $router;
 require_once APP_DIR . 'config/routes.php';
 
 /**
+ * Attribute-based routing (PHP >= 8.0 only)
+ *
+ * Auto-discovers controllers under app/controllers/ that carry
+ * #[Route]/#[Get]/#[Post]/etc attributes and registers them onto
+ * the same $router instance used above. Controllers with no
+ * attributes (e.g. Welcome.php) are left completely untouched, and
+ * routes.php remains the manual registration path — nothing here
+ * is required to keep using string-callback routes.
+ *
+ * On PHP 7.4 (LavaLust's stated minimum) this block is skipped
+ * silently since #[Attribute] syntax doesn't parse pre-8.0.
+ */
+if (PHP_VERSION_ID >= 80000) {
+    require_once SYSTEM_DIR . 'kernel/Attributes.php';
+    require_once SYSTEM_DIR . 'kernel/AttributeRouteLoader.php';
+    (new AttributeRouteLoader($router))->load();
+}
+
+/**
  * Load app-level kernel extensions (MY_* overrides)
  * Allows extending any kernel class without touching core files.
  */

--- a/smoke_test.php
+++ b/smoke_test.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Smoke-test suite for UserController attribute routes.
+ *
+ * Usage:
+ *   1. Start the dev server from the project root:
+ *        php8.3 -S localhost:8000 -t public/
+ *
+ *   2. In another terminal:
+ *        php8.3 tests/users_smoke_test.php
+ *
+ *      Or point at a different host:
+ *        BASE_URL=http://localhost:8080 php8.3 tests/users_smoke_test.php
+ *
+ * The script reseeds runtime/users_db.json before running so the
+ * suite is fully idempotent — safe to run multiple times in a row.
+ */
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+$BASE     = rtrim(getenv('BASE_URL') ?: 'http://localhost:3000', '/') . '/users';
+$DB_PATH  = __DIR__ . '/../runtime/users_db.json';
+$DB_SEED  = [
+    'next_id' => 4,
+    'rows'    => [
+        '1' => ['id' => 1, 'name' => 'Alice', 'email' => 'alice@example.com', 'role' => 'admin'],
+        '2' => ['id' => 2, 'name' => 'Bob',   'email' => 'bob@example.com',   'role' => 'user'],
+        '3' => ['id' => 3, 'name' => 'Carol', 'email' => 'carol@example.com', 'role' => 'user'],
+    ],
+];
+
+// Reseed so every run starts from a known state.
+file_put_contents($DB_PATH, json_encode($DB_SEED, JSON_PRETTY_PRINT));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function req(string $method, string $url, ?array $body = null): array
+{
+    $ch      = curl_init($url);
+    $headers = ['Accept: application/json'];
+
+    if ($body !== null) {
+        $headers[] = 'Content-Type: application/json';
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($body));
+    }
+
+    curl_setopt_array($ch, [
+        CURLOPT_CUSTOMREQUEST  => strtoupper($method),
+        CURLOPT_HTTPHEADER     => $headers,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT        => 5,
+    ]);
+
+    $raw  = curl_exec($ch);
+    $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $err  = curl_error($ch);
+    curl_close($ch);
+
+    if ($err) {
+        echo "\033[31m[CURL ERROR]\033[0m $err\n";
+        echo "Is the dev server running?  php8.3 -S localhost:8000 -t public/\n";
+        exit(2);
+    }
+
+    return [
+        'code' => $code,
+        'body' => json_decode($raw ?: '{}', true) ?? [],
+    ];
+}
+
+$pass = $fail = 0;
+$log  = [];
+
+function check(string $label, bool $ok, string $detail = ''): void
+{
+    global $pass, $fail, $log;
+    if ($ok) {
+        $pass++;
+        $log[] = "  \033[32m✓\033[0m  $label";
+    } else {
+        $fail++;
+        $log[] = "  \033[31m✗\033[0m  $label" . ($detail ? "\n       ↳ $detail" : '');
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+echo "\n\033[1mUserController — smoke tests\033[0m\n";
+echo str_repeat('─', 55) . "\n";
+
+// 1 ── GET /users  →  200, non-empty data array
+$r = req('GET', "$BASE/");
+check(
+    'GET /users — 200 with data array',
+    $r['code'] === 200
+        && ($r['body']['success'] ?? false) === true
+        && is_array($r['body']['data'] ?? null)
+        && count($r['body']['data']) > 0,
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 2 ── GET /users/1  →  200, id=1
+$r = req('GET', "$BASE/1");
+check(
+    'GET /users/1 — 200 with correct user',
+    $r['code'] === 200 && ($r['body']['data']['id'] ?? null) === 1,
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 3 ── GET /users/999  →  404
+$r = req('GET', "$BASE/999");
+check(
+    'GET /users/999 — 404 not found',
+    $r['code'] === 404 && ($r['body']['success'] ?? true) === false,
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 4 ── POST /users — valid payload  →  201
+$r      = req('POST', "$BASE/", ['name' => 'Dave', 'email' => 'dave@example.com']);
+$new_id = $r['body']['data']['id'] ?? null;
+check(
+    'POST /users — 201 created with id',
+    $r['code'] === 201 && $new_id !== null,
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 5 ── POST /users — empty name  →  422
+$r = req('POST', "$BASE/", ['name' => '', 'email' => 'x@x.com']);
+check(
+    'POST /users — 422 on empty name',
+    $r['code'] === 422 && isset($r['body']['errors']['name']),
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 6 ── POST /users — bad email format  →  422
+$r = req('POST', "$BASE/", ['name' => 'Eve', 'email' => 'not-an-email']);
+check(
+    'POST /users — 422 on invalid email format',
+    $r['code'] === 422 && isset($r['body']['errors']['email']),
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 7 ── POST /users — duplicate email  →  422
+$r = req('POST', "$BASE/", ['name' => 'Dup', 'email' => 'alice@example.com']);
+check(
+    'POST /users — 422 on duplicate email',
+    $r['code'] === 422 && isset($r['body']['errors']['email']),
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 8 ── PUT /users/1 — full update  →  200, name changed
+$r = req('PUT', "$BASE/1", ['name' => 'Alice Updated', 'email' => 'alice2@example.com', 'role' => 'admin']);
+check(
+    'PUT /users/1 — 200 full update',
+    $r['code'] === 200 && ($r['body']['data']['name'] ?? '') === 'Alice Updated',
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 9 ── PUT /users/1 — missing role  →  422
+$r = req('PUT', "$BASE/1", ['name' => 'Alice', 'email' => 'alice2@example.com']); // no role
+check(
+    'PUT /users/1 — 422 missing role',
+    $r['code'] === 422 && isset($r['body']['errors']['role']),
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 10 ── PATCH /users/2 — partial update  →  200, email changed
+$r = req('PATCH', "$BASE/2", ['email' => 'bob-new@example.com']);
+check(
+    'PATCH /users/2 — 200 partial update',
+    $r['code'] === 200 && ($r['body']['data']['email'] ?? '') === 'bob-new@example.com',
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 11 ── PATCH /users/2 — empty body  →  422
+$r = req('PATCH', "$BASE/2", []);
+check(
+    'PATCH /users/2 — 422 on empty body',
+    $r['code'] === 422,
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 12 ── PATCH /users/999 — not found  →  404
+$r = req('PATCH', "$BASE/999", ['name' => 'Ghost']);
+check(
+    'PATCH /users/999 — 404 not found',
+    $r['code'] === 404,
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 13 ── DELETE /users/{new_id}  →  200  (user from test 4)
+if ($new_id !== null) {
+    $r = req('DELETE', "$BASE/$new_id");
+    check(
+        "DELETE /users/$new_id — 200 deleted",
+        $r['code'] === 200 && ($r['body']['success'] ?? false) === true,
+        "HTTP {$r['code']} | " . json_encode($r['body'])
+    );
+} else {
+    check('DELETE /users/{new_id} — skipped (creation failed)', false, 'user was never created in test 4');
+}
+
+// 14 ── DELETE /users/999  →  404
+$r = req('DELETE', "$BASE/999");
+check(
+    'DELETE /users/999 — 404 not found',
+    $r['code'] === 404,
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// 15 ── GET /users/1 — name must reflect the PUT from test 8
+$r = req('GET', "$BASE/1");
+check(
+    'GET /users/1 — name persisted after PUT',
+    $r['code'] === 200 && ($r['body']['data']['name'] ?? '') === 'Alice Updated',
+    "HTTP {$r['code']} | " . json_encode($r['body'])
+);
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+echo "\n";
+foreach ($log as $line) {
+    echo $line . "\n";
+}
+
+$total  = $pass + $fail;
+$colour = $fail === 0 ? "\033[32m" : "\033[31m";
+echo "\n" . str_repeat('─', 55) . "\n";
+echo "{$colour}Results: $pass / $total passed";
+if ($fail > 0) {
+    echo " | $fail FAILED";
+}
+echo "\033[0m\n\n";
+
+exit($fail > 0 ? 1 : 0);


### PR DESCRIPTION
# Attribute-based routing for LavaLust

## Summary

Adds PHP 8 attribute support (`#[Route]`, `#[Get]`, `#[Post]`, etc.) as an
alternative way to define controller routes, alongside the existing
`app/config/routes.php` style. This is purely additive — no existing
routing behavior changes.

## What's new

- `scheme/kernel/Attributes.php` — `Route`, `Get`, `Post`, `Put`, `Patch`,
  `Delete`, `UseMiddleware`, `Where`, `Name` attribute classes.
- `scheme/kernel/AttributeRouteLoader.php` — recursively scans
  `app/controllers/`, reflects attributed controllers, and registers
  routes through Router's existing public API (`get()`, `post()`,
  `match()`, `->middleware()`, `->where()`, `->name()`). `Router.php`
  itself is not modified.
- `app/controllers/UserController.php` — full RESTful example controller
  backed by a JSON flat-file store (`runtime/users_db.json`) that
  survives across PHP dev-server requests and can be swapped for a real
  Model with no routing changes.
- `runtime/users_db.json` — seed data for the example controller.
- `tests/users_smoke_test.php` — 15-case curl-based smoke test suite
  (idempotent: reseeds the JSON store before every run).

## Key behavior

- Class-level `#[Route('/prefix')]` sets the URL prefix for every
  attributed method in that controller.
- Middleware chains: class-level `#[UseMiddleware('auth')]` runs before
  method-level `#[UseMiddleware('throttle', 'csrf')]`, in declared order.
- Auto-discovery — any attributed controller in `app/controllers/` is
  picked up automatically; nothing to register in config.
- `{id}` alone infers a numeric constraint (`id` / `*_id` params) — no
  `#[Where(...)]` needed for the common case. Raw regex and shorthand
  tokens (`int`, `alpha`, `slug`, `uuid`, `ulid`) are supported inline,
  e.g. `{code:[0-9]{4}}`. Explicit `#[Where(...)]` still overrides.
- `#[Route('/{id}', methods: ['PUT', 'PATCH'])]` for multi-verb routes
  handled by one method.

## Backward compatibility

- `app/config/routes.php` and string-callback routes work exactly as
  before, untouched.
- Controllers with no attributes (e.g. `Welcome.php`) are skipped after
  one cheap `getAttributes()` check.
- Gated behind `PHP_VERSION_ID >= 80000` in `LavaLust.php` — on PHP 7.4
  (the framework's stated minimum) this is a silent no-op, since
  `#[Attribute]` syntax doesn't parse pre-8.0 anyway.
- `Router.php` and `Controller.php` are unmodified. Only `LavaLust.php`
  changed, adding one `if` block after the existing
  `require_once APP_DIR . 'config/routes.php'` line.
- Attribute classes were named to avoid colliding with existing framework
  classes — notably `UseMiddleware` instead of `Middleware`, since
  `scheme/kernel/Middleware.php` already declares a global `Middleware`
  class (the middleware pipeline runner).

---

## Full example — `app/controllers/UserController.php`

```php
<?php
defined('PREVENT_DIRECT_ACCESS') OR exit('No direct script access allowed');

/**
 * UserController
 *
 * RESTful user resource using PHP 8 attribute-based routing.
 *
 * Routes (prefix from #[Route('/users')] on the class):
 *   GET    /users          -> index()    list all users
 *   GET    /users/{id}     -> show()     get one user  [named: users.show]
 *   POST   /users          -> store()    create a user
 *   PUT    /users/{id}     -> update()   full update
 *   PATCH  /users/{id}     -> update()   partial update (same handler)
 *   DELETE /users/{id}     -> destroy()  delete a user
 *
 * Persistence: runtime/users_db.json (file-based store that survives
 * across PHP dev-server requests). Swap read_db()/write_db() for a
 * real Model when you add a database.
 */
#[Route('/users')]
class UserController extends Controller
{
    // ----------------------------------------------------------------
    // Flat-file store helpers
    // ----------------------------------------------------------------

    /** Absolute path to the JSON store. */
    private function db_path(): string
    {
        // APP_DIR is defined by LavaLust as the app/ directory.
        // runtime/ sits one level up alongside app/.
        return rtrim(APP_DIR, '/\\') . '/../runtime/users_db.json';
    }

    /**
     * Read the entire store from disk.
     * Returns ['next_id' => int, 'rows' => [id => row, ...]]
     */
    private function read_db(): array
    {
        $path = $this->db_path();

        if (!file_exists($path)) {
            return ['next_id' => 1, 'rows' => []];
        }

        $data = json_decode(file_get_contents($path), true);

        return is_array($data) ? $data : ['next_id' => 1, 'rows' => []];
    }

    /** Persist the store back to disk (pretty-printed for readability). */
    private function write_db(array $data): void
    {
        file_put_contents(
            $this->db_path(),
            json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
        );
    }

    // ----------------------------------------------------------------
    // GET /users
    // ----------------------------------------------------------------

    #[Get('/')]
    public function index()
    {
        $db = $this->read_db();

        $this->response->send_json_success(
            array_values($db['rows']),
            'Users retrieved successfully'
        );
    }

    // ----------------------------------------------------------------
    // GET /users/{id}
    // ----------------------------------------------------------------

    #[Get('/{id}')]
    #[Name('users.show')]
    public function show($id)
    {
        $id  = (int) $id;
        $db  = $this->read_db();
        $row = $db['rows'][$id] ?? null;

        if ($row === null) {
            $this->response->send_json_error("User $id not found", 404);
            return;
        }

        $this->response->send_json_success($row, 'User retrieved successfully');
    }

    // ----------------------------------------------------------------
    // POST /users
    // ----------------------------------------------------------------

    #[Post('/')]
    public function store()
    {
        $body   = $this->request->json();
        $db     = $this->read_db();
        $errors = [];

        // --- validate ---
        if (empty($body['name'])) {
            $errors['name'] = 'The name field is required.';
        }

        if (empty($body['email'])) {
            $errors['email'] = 'The email field is required.';
        } elseif (!filter_var($body['email'], FILTER_VALIDATE_EMAIL)) {
            $errors['email'] = 'The email must be a valid email address.';
        } else {
            foreach ($db['rows'] as $row) {
                if (strtolower($row['email']) === strtolower($body['email'])) {
                    $errors['email'] = 'This email is already taken.';
                    break;
                }
            }
        }

        if (!empty($errors)) {
            $this->response->send_json_validation($errors);
            return;
        }

        // --- persist ---
        $id  = (int) $db['next_id'];
        $row = [
            'id'    => $id,
            'name'  => trim($body['name']),
            'email' => strtolower(trim($body['email'])),
            'role'  => isset($body['role']) ? trim($body['role']) : 'user',
        ];

        $db['rows'][$id] = $row;
        $db['next_id']   = $id + 1;
        $this->write_db($db);

        $this->response->send_created($row);
    }

    // ----------------------------------------------------------------
    // PUT /users/{id}  +  PATCH /users/{id}
    // ----------------------------------------------------------------

    #[Route('/{id}', methods: ['PUT', 'PATCH'])]
    public function update($id)
    {
        $id     = (int) $id;
        $db     = $this->read_db();
        $row    = $db['rows'][$id] ?? null;

        if ($row === null) {
            $this->response->send_json_error("User $id not found", 404);
            return;
        }

        $method = $this->request->method(true); // 'PUT' or 'PATCH'
        $body   = $this->request->json();
        $errors = [];

        if (empty($body)) {
            $this->response->send_json_error('Request body must not be empty.', 422);
            return;
        }

        // PUT requires every writable field; PATCH allows a subset.
        if ($method === 'PUT') {
            if (!isset($body['name']))  $errors['name']  = 'The name field is required for a full update.';
            if (!isset($body['email'])) $errors['email'] = 'The email field is required for a full update.';
            if (!isset($body['role']))  $errors['role']  = 'The role field is required for a full update.';
        }

        if (isset($body['email'])) {
            if (!filter_var($body['email'], FILTER_VALIDATE_EMAIL)) {
                $errors['email'] = 'The email must be a valid email address.';
            } else {
                foreach ($db['rows'] as $uid => $existing) {
                    if ((int) $uid !== $id && strtolower($existing['email']) === strtolower($body['email'])) {
                        $errors['email'] = 'This email is already taken.';
                        break;
                    }
                }
            }
        }

        if (!empty($errors)) {
            $this->response->send_json_validation($errors);
            return;
        }

        // Apply only the fields that were sent.
        foreach (['name', 'email', 'role'] as $field) {
            if (isset($body[$field])) {
                $row[$field] = is_string($body[$field]) ? trim($body[$field]) : $body[$field];
            }
        }

        $db['rows'][$id] = $row;
        $this->write_db($db);

        $this->response->send_json_success($row, 'User updated successfully');
    }

    // ----------------------------------------------------------------
    // DELETE /users/{id}
    // ----------------------------------------------------------------

    #[Delete('/{id}')]
    public function destroy($id)
    {
        $id = (int) $id;
        $db = $this->read_db();

        if (!isset($db['rows'][$id])) {
            $this->response->send_json_error("User $id not found", 404);
            return;
        }

        $deleted = $db['rows'][$id];
        unset($db['rows'][$id]);
        $this->write_db($db);

        $this->response->send_json_success($deleted, "User $id deleted successfully");
    }
}
```

---

## Testing

### Running the smoke test

```bash
# Terminal 1 — start the dev server from the project root
php8.3 -S localhost:3000 -t public/

# Terminal 2 — run the suite (reseeds the JSON store automatically)
php smoke_test.php

# Override the base URL if your setup differs
BASE_URL=http://localhost/lavalust php smoke_test.php
```

### What the suite covers (15 cases)

| # | Method | Path | Scenario | Expected |
|---|--------|------|----------|----------|
| 1 | GET | `/users` | list all | 200, non-empty array |
| 2 | GET | `/users/1` | existing user | 200, `id=1` |
| 3 | GET | `/users/999` | missing user | 404 |
| 4 | POST | `/users` | valid payload | 201, id returned |
| 5 | POST | `/users` | empty name | 422, `errors.name` |
| 6 | POST | `/users` | bad email format | 422, `errors.email` |
| 7 | POST | `/users` | duplicate email | 422, `errors.email` |
| 8 | PUT | `/users/1` | full update | 200, name changed |
| 9 | PUT | `/users/1` | missing `role` field | 422, `errors.role` |
| 10 | PATCH | `/users/2` | partial update (email only) | 200, email changed |
| 11 | PATCH | `/users/2` | empty body | 422 |
| 12 | PATCH | `/users/999` | missing user | 404 |
| 13 | DELETE | `/users/{id}` | user created in #4 | 200 |
| 14 | DELETE | `/users/999` | missing user | 404 |
| 15 | GET | `/users/1` | read-back after PUT in #8 | 200, name persisted |

### Why file-based persistence matters

PHP's built-in dev server (`php -S`) spawns a **new process per request**,
so any in-memory state (`static $db`, class properties) resets between hits.
Tests 13 and 15 — which verify that a POST-created user can be deleted and
that a PUT mutation survives a subsequent GET — both failed with an in-memory
store. `runtime/users_db.json` is read and written on every request, so
mutations are visible across process boundaries.

The smoke test script **reseeds the JSON file** (`Alice/Bob/Carol`,
`next_id=4`) as its very first step, making the suite fully idempotent and
safe to run repeatedly.

### Response envelope

All endpoints use the structured envelope from `Response`:

```jsonc
// success
{ "success": true,  "message": "...", "data": { ... } }

// error
{ "success": false, "error": "..." }

// validation failure (422)
{ "success": false, "error": "Validation failed", "errors": { "field": "message" } }
```

### Manual Thunder Client collection

Import `tests/thunder_collection.json` into Thunder Client
(Collections → Import) for a one-click GUI alternative.

---

## Files changed

```
scheme/kernel/Attributes.php          new — Route/Get/Post/Put/Patch/Delete/
                                            UseMiddleware/Where/Name classes
scheme/kernel/AttributeRouteLoader.php new — reflection scanner + router bridge
scheme/kernel/LavaLust.php            modified — +8 lines after routes.php require
app/controllers/UserController.php    new — RESTful example with file-backed store
runtime/users_db.json                 new — seed data for the example controller
tests/users_smoke_test.php            new — 15-case idempotent smoke test
```